### PR TITLE
Fixed cookiecutter dictionary with missing attributes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,5 +17,6 @@
     "domain_name": "example.com",
     "license": ["MIT", "Apache", "GPLv3", "No License" ],
     "current_year": "2015",
-    "full_legal_name_of_project_owner": ""
+    "full_legal_name_of_project_owner": "",
+    "use_celery": ["no", "yes"]
 }

--- a/{{cookiecutter.repo_name}}/.pylintrc
+++ b/{{cookiecutter.repo_name}}/.pylintrc
@@ -1,5 +1,5 @@
 [MASTER]
-load-plugins=pylint_common, pylint_django{% if cookiecutter.use_celery == "y" %}, pylint_celery {% endif %}
+load-plugins=pylint_common, pylint_django{% if cookiecutter.use_celery == "yes" %}, pylint_celery {% endif %}
 
 [FORMAT]
 max-line-length=120

--- a/{{cookiecutter.repo_name}}/config/settings/common.py
+++ b/{{cookiecutter.repo_name}}/config/settings/common.py
@@ -179,7 +179,7 @@ ROOT_URLCONF = 'config.urls'
 # ------------------------------------------------------------------------------
 
 ADMINS = (
-    ("""{{cookiecutter.author_name}}""", '{{cookiecutter.email}}'),
+    ("""{{cookiecutter.author_name}}""", '{{cookiecutter.author_email}}'),
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#managers


### PR DESCRIPTION
There was lacking "use_celery" attribute in cookiecutter json dictionary and in django settings email should be author_email.